### PR TITLE
change path back on header/footer

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,5 +3,5 @@ Please always provide the [GitHub issue(s)](../issues) your PR is for, as well a
 Fix #<gh-issue-id>
 
 Test URLs:
-- Before: https://main--dsp-xwalk--helms-charity.aem.page/content/dsp-xwalk
-- After: https://<branch>--dsp-xwalk--helms-charity.aem.page/content/dsp-xwalk
+- Before: https://main--dsp-xwalk--helms-charity.aem.page
+- After: https://<branch>--dsp-xwalk--helms-charity.aem.page

--- a/blocks/footer/footer.js
+++ b/blocks/footer/footer.js
@@ -8,7 +8,7 @@ import { loadFragment } from '../fragment/fragment.js';
 export default async function decorate(block) {
   // load footer as fragment
   const footerMeta = getMetadata('footer');
-  const footerPath = footerMeta ? new URL(footerMeta, window.location).pathname : '/content/dsp-xwalk/footer';
+  const footerPath = footerMeta ? new URL(footerMeta, window.location).pathname : '/footer';
   const fragment = await loadFragment(footerPath);
 
   // decorate footer DOM

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -110,7 +110,7 @@ function toggleMenu(nav, navSections, forceExpanded = null) {
 export default async function decorate(block) {
   // load nav as fragment
   const navMeta = getMetadata('nav');
-  const navPath = navMeta ? new URL(navMeta, window.location).pathname : '/content/dsp-xwalk/nav';
+  const navPath = navMeta ? new URL(navMeta, window.location).pathname : '/nav';
   const fragment = await loadFragment(navPath);
 
   // decorate nav DOM


### PR DESCRIPTION

Fix #3 

Test URLs:
- Before: https://main--dsp-xwalk--helms-charity.aem.page
- After: https://3-gitignore--dsp-xwalk--helms-charity.aem.page
